### PR TITLE
adds fix for #4856

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -238,7 +238,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
                                                              placeholder_id=self.placeholder_id).count()
                 self.add_root(instance=self)
             return
-        super(CMSPlugin, self).save()
+        super(CMSPlugin, self).save(*args, **kwargs)
 
     def reload(self):
         return CMSPlugin.objects.get(pk=self.pk)

--- a/cms/utils/copy_plugins.py
+++ b/cms/utils/copy_plugins.py
@@ -29,6 +29,11 @@ def copy_plugins_to(old_plugins, to_placeholder,
         for idx, plugin in enumerate(new_plugins):
             if plugin.parent_id is None:
                 plugin.parent_id = parent_plugin_id
+                # Always use update fields to avoid side-effects.
+                # In this case "plugin" has invalid values for internal fields
+                # like numchild.
+                # The invalid value is only in memory because the instance
+                # was never updated.
                 plugin.save(update_fields=['parent'])
                 new_plugins[idx] = plugin.move(parent_plugin, pos="last-child")
 

--- a/cms/utils/copy_plugins.py
+++ b/cms/utils/copy_plugins.py
@@ -29,7 +29,7 @@ def copy_plugins_to(old_plugins, to_placeholder,
         for idx, plugin in enumerate(new_plugins):
             if plugin.parent_id is None:
                 plugin.parent_id = parent_plugin_id
-                plugin.save()
+                plugin.save(update_fields=['parent'])
                 new_plugins[idx] = plugin.move(parent_plugin, pos="last-child")
 
     plugins_ziplist = list(zip(new_plugins, old_plugins))


### PR DESCRIPTION
The `save()` method has not accepted arguments for years :cry: 

Fixes https://github.com/divio/django-cms/issues/4856
