### PR TITLE
Fixe test_page_admin for Django 1.8

### DIFF
--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import sys
 
+import django
 from django.core.cache import cache
 from django.core.urlresolvers import clear_url_caches
 from django.contrib import admin
@@ -1160,7 +1161,10 @@ class PageTest(PageTestBase):
             response = self.client.post(endpoint, payload)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json().get('status', 400), 400)
+            if django.VERSION < (1,9):
+                self.assertEqual(response.get('status', 400), 400)
+            else:
+                self.assertEqual(response.json().get('status', 400), 400)
 
     def test_move_home_page(self):
         """


### PR DESCRIPTION
### Summary

Fixe test_page_admin for 3.5.3 milestone


### Links to related discussion
 #6002



### Proposed changes in this pull request
avoid using response.json() for django 1.8 that does not work.
